### PR TITLE
Fix serializer attributes for some Resumes serializers

### DIFF
--- a/app/serializers/yoksis/resumes/articles_serializer.rb
+++ b/app/serializers/yoksis/resumes/articles_serializer.rb
@@ -27,7 +27,7 @@ module Yoksis
       attribute(:last_update)               { parse_datetime object[:guncelleme_tarihi]                    }
       attribute(:month)                     { integer        object[:ay]                                   }
       attribute(:name)                      { string         object[:makale_adi]                           }
-      attribute(:number_of_author)          { integer        object[:yazar_sayisi]                         }
+      attribute(:number_of_authors)         { integer        object[:yazar_sayisi]                         }
       attribute(:number_of_citations)       { integer        object[:atif_sayisi]                          }
       attribute(:publication_id)            { integer        object[:yayin_id]                             }
       attribute(:publication_language_id)   { integer        object[:yayin_dili]                           }
@@ -38,6 +38,7 @@ module Yoksis
       attribute(:scope_name)                { string         object[:kapsam_ad]                            }
       attribute(:special_issue_id)          { integer        object[:ozel_sayi]                            }
       attribute(:special_issue_name)        { string         object[:ozel_sayi_ad]                         }
+      attribute(:sponsored_by)              { string         object[:sponsor]                              }
       attribute(:type_id)                   { integer        object[:makale_turu_id]                       }
       attribute(:type_name)                 { string         object[:makale_turu_ad]                       }
       attribute(:volume)                    { integer        object[:cilt]                                 }

--- a/app/serializers/yoksis/resumes/certifications_serializer.rb
+++ b/app/serializers/yoksis/resumes/certifications_serializer.rb
@@ -3,25 +3,25 @@
 module Yoksis
   module Resumes
     class CertificationsSerializer < Serializer
-      attribute(:activity_id)      { integer        object[:aktif_pasif]       }
-      attribute(:activity_name)    { string         object[:aktif_pasif_ad]    }
-      attribute(:content)          { string         object[:icerik]            }
-      attribute(:country)          { string         object[:ulke_sehir]        }
-      attribute(:incentive_point)  { float          object[:tesv_puan]         }
-      attribute(:last_update)      { parse_datetime object[:guncelleme_tarihi] }
-      attribute(:location)         { string         object[:yer]               }
-      attribute(:name)             { string         object[:adi]               }
-      attribute(:number_of_person) { integer        object[:kisi_sayisi]       }
-      attribute(:scope_id)         { integer        object[:kapsam]            }
-      attribute(:scope_name)       { string         object[:kapsam_ad]         }
-      attribute(:stint)            { integer        object[:sure]              }
-      attribute(:title_id)         { integer        object[:unvan_id]          }
-      attribute(:title_name)       { string         object[:unvan_ad]          }
-      attribute(:type_id)          { integer        object[:tur_id]            }
-      attribute(:type_name)        { string         object[:tur_adi]           }
-      attribute(:unit_id)          { integer        object[:kurum_id]          }
-      attribute(:unit_name)        { string         object[:kurum_ad]          }
-      attribute(:yoksis_id)        { integer        object[:s_id]              }
+      attribute(:activity_id)       { integer        object[:aktif_pasif]       }
+      attribute(:activity_name)     { string         object[:aktif_pasif_ad]    }
+      attribute(:city_and_country)  { string         object[:ulke_sehir]        }
+      attribute(:content)           { string         object[:icerik]            }
+      attribute(:duration)          { integer        object[:sure]              }
+      attribute(:incentive_point)   { float          object[:tesv_puan]         }
+      attribute(:last_update)       { parse_datetime object[:guncelleme_tarihi] }
+      attribute(:location)          { string         object[:yer]               }
+      attribute(:name)              { string         object[:adi]               }
+      attribute(:number_of_authors) { integer        object[:kisi_sayisi]       }
+      attribute(:scope_id)          { integer        object[:kapsam]            }
+      attribute(:scope_name)        { string         object[:kapsam_ad]         }
+      attribute(:title_id)          { integer        object[:unvan_id]          }
+      attribute(:title_name)        { string         object[:unvan_ad]          }
+      attribute(:type_id)           { integer        object[:tur_id]            }
+      attribute(:type_name)         { string         object[:tur_adi]           }
+      attribute(:unit_id)           { integer        object[:kurum_id]          }
+      attribute(:unit_name)         { string         object[:kurum_ad]          }
+      attribute(:yoksis_id)         { integer        object[:s_id]              }
 
       attribute :start_date do
         next unless object[:bastar]


### PR DESCRIPTION
**Açıklama**

Resumes endpoint'i altındaki bazı action serializer'ların attribute'larını Nokul ile uyumlu hale getirir.

**Kapatacağı iş kaydı**

n/a

**Veritabanına etkileri**

n/a

**Kontrol listesi**

- [X] PR başlığının sadece ilk harfi büyük, yazım kurallarına uygun ve emir kipinde
- [X] [Katkı sağlama dokümanına](https://github.com/omu/xokul/CONTRIBUTING.md) uygun
- [X] Test coverage, kod kalite vb. tüm entegrasyonlar başarıyla geçiyor ve negatif etki (düşüş) yaratmıyor
- [X] Gerekli etiketler verildi